### PR TITLE
Fix: Segment Exception when $analytics->flush() is used in dev or test environment

### DIFF
--- a/Util/SegmentIoProvider.php
+++ b/Util/SegmentIoProvider.php
@@ -101,7 +101,10 @@ class SegmentIoProvider
      */
     public function flush()
     {
-        return Analytics::flush();
+        if ($this->environment == self::SEGMENT_IO_PROVIDER__ENV_PROD) {
+            return Analytics::flush();
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Fix the problem when $analytics->flush() is used in dev or test environment.

In that case Segment will return: 
`[Exception] Segment::init() must be called before any other tracking method.` 
(Segment.php line 131)
