### PR TITLE
Make bundle work with empty write_key (=disabled)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,8 +23,6 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('write_key')
-                    ->cannotBeEmpty()
-                    ->isRequired()
                 ->end()
                 ->enumNode('env')
                     ->values(['dev', 'prod'])

--- a/Util/SegmentIoProvider.php
+++ b/Util/SegmentIoProvider.php
@@ -28,6 +28,12 @@ class SegmentIoProvider
     private $environment;
 
     /**
+     * @var bool
+     * isEnabled
+     */
+    private $isEnabled;
+
+    /**
      * SegmentIoProvider constructor.
      *
      * @param $key
@@ -37,7 +43,8 @@ class SegmentIoProvider
     public function __construct($key, $environment, array $options)
     {
         $this->environment = $environment;
-        if ($this->environment == self::SEGMENT_IO_PROVIDER__ENV_PROD) {
+        $this->isEnabled = $this->environment == self::SEGMENT_IO_PROVIDER__ENV_PROD && $key;
+        if ($this->isEnabled) {
             Analytics::init($key, $options);
         }
     }
@@ -45,7 +52,7 @@ class SegmentIoProvider
 
     private function process($name, array $params)
     {
-        if ($this->environment == self::SEGMENT_IO_PROVIDER__ENV_PROD) {
+        if ($this->isEnabled) {
             return Analytics::$name($params);
         }
         return true;
@@ -101,7 +108,7 @@ class SegmentIoProvider
      */
     public function flush()
     {
-        if ($this->environment == self::SEGMENT_IO_PROVIDER__ENV_PROD) {
+        if ($this->isEnabled) {
             return Analytics::flush();
         }
         return true;


### PR DESCRIPTION
Hi! To be able to use the bundle in different environments (all running in prod mode), but only enable tracking on certain environments (e.g. production vs staging), I slightly modified it to allow an empty write_key, which disables tracking.