### PR TITLE
Remove deprecation message and fix typo

### DIFF
--- a/Configuration/AnalyticsInterface.php
+++ b/Configuration/AnalyticsInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * This file is part of the SegmentIoBundle project.
+ *
+ * (c) Vladislav Marin <vladislav.marin92@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT
+ */
+
 namespace Farmatholin\SegmentIoBundle\Configuration;
 
 /**
@@ -8,8 +19,6 @@ namespace Farmatholin\SegmentIoBundle\Configuration;
  * Interface AnalyticsInterface
  *
  * @author Vladislav Marin <vladislav.marin92@gmail.com>
- *
- * @package Farmatholin\SegmentIoBundle\Configuration
  */
 interface AnalyticsInterface
 {

--- a/Configuration/Page.php
+++ b/Configuration/Page.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * This file is part of the SegmentIoBundle project.
+ *
+ * (c) Vladislav Marin <vladislav.marin92@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT
+ */
+
 namespace Farmatholin\SegmentIoBundle\Configuration;
 
 use Doctrine\Common\Annotations\Annotation;
@@ -10,9 +21,8 @@ use Doctrine\Common\Annotations\Annotation\Required;
  *
  * @author Vladislav Marin <vladislav.marin92@gmail.com>
  *
- * @package Farmatholin\SegmentIoBundle\Configuration
- *
  * @Annotation
+ *
  * @Target("METHOD")
  */
 class Page implements AnalyticsInterface
@@ -47,7 +57,8 @@ class Page implements AnalyticsInterface
     }
 
     /**
-     * @param $category
+     * @param string $category
+     *
      * @return $this
      */
     public function setCategory($category)
@@ -66,7 +77,8 @@ class Page implements AnalyticsInterface
     }
 
     /**
-     * @param $name
+     * @param string $name
+     *
      * @return $this
      */
     public function setName($name)
@@ -85,7 +97,7 @@ class Page implements AnalyticsInterface
     }
 
     /**
-     * @param $properties
+     * @param array $properties
      */
     public function setProperties($properties)
     {

--- a/Configuration/Track.php
+++ b/Configuration/Track.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * This file is part of the SegmentIoBundle project.
+ *
+ * (c) Vladislav Marin <vladislav.marin92@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT
+ */
+
 namespace Farmatholin\SegmentIoBundle\Configuration;
 
 use Doctrine\Common\Annotations\Annotation;
@@ -9,8 +20,6 @@ use Doctrine\Common\Annotations\Annotation\Required;
  * Annotation Track
  *
  * @author Vladislav Marin <vladislav.marin92@gmail.com>
- *
- * @package Farmatholin\SegmentIoBundle\Configuration
  *
  * @Annotation
  * @Target("METHOD")
@@ -103,6 +112,7 @@ class Track implements AnalyticsInterface
         $this->useTimestamp = $useTimestamp;
     }
 
+    /** @noinspection PhpDocMissingThrowsInspection */
     /**
      * @return array
      */
@@ -115,8 +125,10 @@ class Track implements AnalyticsInterface
         ];
 
         if ($this->isUseTimestamp()) {
+            /** @noinspection PhpUnhandledExceptionInspection */
             $result['timestamp'] = (new \DateTime())->getTimestamp();
         }
-        return  $result;
+
+        return $result;
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,8 +20,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('segment_io');
+        $treeBuilder = new TreeBuilder('segment_io');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('segment_io');
+        }
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * This file is part of the SegmentIoBundle project.
+ *
+ * (c) Vladislav Marin <vladislav.marin92@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT
+ */
+
 namespace Farmatholin\SegmentIoBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -9,8 +20,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * Class Configuration
  *
  * @author Vladislav Marin <vladislav.marin92@gmail.com>
- *
- * @package Farmatholin\SegmentIoBundle\DependencyInjection
  */
 class Configuration implements ConfigurationInterface
 {
@@ -68,6 +77,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
             ;
+
         return $treeBuilder;
     }
 }

--- a/DependencyInjection/SegmentIoExtension.php
+++ b/DependencyInjection/SegmentIoExtension.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * This file is part of the SegmentIoBundle project.
+ *
+ * (c) Vladislav Marin <vladislav.marin92@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT
+ */
+
 namespace Farmatholin\SegmentIoBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -11,21 +22,21 @@ use Symfony\Component\DependencyInjection\Loader;
  * Class SegmentIoExtension
  *
  * @author Vladislav Marin <vladislav.marin92@gmail.com>
- *
- * @package Farmatholin\SegmentIoBundle\DependencyInjection
  */
 class SegmentIoExtension extends Extension
 {
     /**
      * @param array            $configs
      * @param ContainerBuilder $container
+     *
+     * @throws \Exception
      */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         $container->setParameter('farma.segment_io_write_key', $config['write_key']);

--- a/EventListener/AnnotationListener.php
+++ b/EventListener/AnnotationListener.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * This file is part of the SegmentIoBundle project.
+ *
+ * (c) Vladislav Marin <vladislav.marin92@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT
+ */
+
 namespace Farmatholin\SegmentIoBundle\EventListener;
 
 use Doctrine\Common\Annotations\Reader;
@@ -13,8 +24,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  * Class AnnotationListener
  *
  * @author Vladislav Marin <vladislav.marin92@gmail.com>
- *
- * @package Farmatholin\SegmentIoBundle\EventListener
  */
 class AnnotationListener
 {
@@ -38,21 +47,15 @@ class AnnotationListener
      */
     protected $guestId;
 
-
     /**
      * AnnotationListener constructor.
      *
-     * @param Reader $reader
+     * @param Reader                $reader
      * @param TokenStorageInterface $tokenStorage
-     * @param SegmentIoProvider $segmentIoProvider
-     * @param string $guestId
+     * @param SegmentIoProvider     $segmentIoProvider
+     * @param string                $guestId
      */
-    public function __construct(
-        Reader $reader,
-        TokenStorageInterface $tokenStorage,
-        SegmentIoProvider $segmentIoProvider,
-        $guestId
-    )
+    public function __construct(Reader $reader, TokenStorageInterface $tokenStorage, SegmentIoProvider $segmentIoProvider, $guestId)
     {
         $this->reader = $reader;
         $this->segmentIoProvider = $segmentIoProvider;
@@ -62,6 +65,8 @@ class AnnotationListener
 
     /**
      * @param FilterControllerEvent $event
+     *
+     * @throws \ReflectionException
      */
     public function onKernelController(FilterControllerEvent $event)
     {
@@ -93,9 +98,7 @@ class AnnotationListener
                 $message = $configuration->getMessage();
                 $message['userId'] = $userId;
 
-                $this->segmentIoProvider->track(
-                    $message
-                );
+                $this->segmentIoProvider->track($message);
 
                 $this->segmentIoProvider->flush();
             }
@@ -105,6 +108,8 @@ class AnnotationListener
 
     /**
      * @return string|null
+     *
+     * @throws \ReflectionException
      */
     private function getUserId()
     {
@@ -118,11 +123,12 @@ class AnnotationListener
 
         $reflect = new \ReflectionClass($user);
         if ($reflect->hasMethod('getId')) {
-            $id = $user->getId();
-            if ($id !== null) {
-                return $id;
+            $userId = $user->getId();
+            if (null !== $userId) {
+                return $userId;
             }
         }
+
         return $this->guestId;
     }
 }

--- a/README.md
+++ b/README.md
@@ -35,23 +35,44 @@ That's it! You are ready to use Segment.io with symfony2.
 
 ## Configuration
 
-Required  segment write key:
+Required segment write key:
+
+### Symfony 4.X :
 
 ```yml
-# SegmentIoBundle Configuration
+# config/packages/segment_io.yml
+
+segment_io:
+    write_key: "%env(SEGMENTIO_KEY)%"  # add your key
+    guest_id: "guest" # default guest. Guest id for annotation Track and Page
+    env: prod #default prod. Can be prod (sending to segment) and dev (not sending)
+    options:
+        consumer: socket #default
+        debug: false #default
+        ssl: false #default
+        max_queue_size: 10000 #default
+        batch_size: 100 #default
+        timeout: 0.5 #default
+        filename: null #default
+```
+
+### Symfony 2.X || 3.X
+
+```yml
 # app/config/config.yml
-        segment_io:
-            write_key: "%your_key%" #add your key
-            guest_id: "guest" # default guest. Guest id for annotation Track and Page
-            env: prod #default prod. Can be prod (sending to segment) and dev (not sending)
-            options:
-                consumer: socket #default
-                debug: false #default
-                ssl: false #default
-                max_queue_size: 10000 #default
-                batch_size: 100 #default
-                timeout: 0.5 #default
-                filename: null #default
+
+    segment_io:
+        write_key: "%your_key%" #add your key
+        guest_id: "guest" # default guest. Guest id for annotation Track and Page
+        env: prod #default prod. Can be prod (sending to segment) and dev (not sending)
+        options:
+            consumer: socket #default
+            debug: false #default
+            ssl: false #default
+            max_queue_size: 10000 #default
+            batch_size: 100 #default
+            timeout: 0.5 #default
+            filename: null #default
 ```
 
 ## Usage

--- a/Util/ErrorHandler.php
+++ b/Util/ErrorHandler.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * This file is part of the SegmentIoBundle project.
+ *
+ * (c) Vladislav Marin <vladislav.marin92@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT
+ */
+
 namespace Farmatholin\SegmentIoBundle\Util;
 
 use Psr\Log\LoggerInterface;
@@ -9,12 +20,14 @@ use Psr\Log\LoggerInterface;
  */
 class ErrorHandler
 {
-
-    /** @var LoggerInterface */
+    /**
+     * @var LoggerInterface
+     */
     protected $logger;
 
     /**
      * ErrorHandler constructor.
+     *
      * @param LoggerInterface $logger
      */
     public function __construct(LoggerInterface $logger)

--- a/Util/SegmentIoProvider.php
+++ b/Util/SegmentIoProvider.php
@@ -1,9 +1,14 @@
 <?php
+
 /**
- * Created by PhpStorm.
- * User: Vladislav
- * Date: 11.11.2015
- * Time: 12:10
+ * This file is part of the SegmentIoBundle project.
+ *
+ * (c) Vladislav Marin <vladislav.marin92@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT
  */
 
 namespace Farmatholin\SegmentIoBundle\Util;
@@ -14,8 +19,6 @@ use Segment as Analytics;
  * Class SegmentIoProvider
  *
  * @author Vladislav Marin <vladislav.marin92@gmail.com>
- *
- * @package Farmatholin\SegmentIoBundle\Util
  */
 class SegmentIoProvider
 {
@@ -23,14 +26,7 @@ class SegmentIoProvider
     const SEGMENT_IO_PROVIDER__ENV_DEV = 'dev';
 
     /**
-     * @var string
-     * environment
-     */
-    private $environment;
-
-    /**
-     * @var bool
-     * isEnabled
+     * @var bool isEnabled
      */
     private $isEnabled;
 
@@ -44,8 +40,7 @@ class SegmentIoProvider
      */
     public function __construct($key, $environment, array $options, ErrorHandler $logger)
     {
-        $this->environment = $environment;
-        $this->isEnabled = $this->environment == self::SEGMENT_IO_PROVIDER__ENV_PROD && $key;
+        $this->isEnabled = $environment === self::SEGMENT_IO_PROVIDER__ENV_PROD && $key;
         $options['error_handler'] = $logger;
         if ($this->isEnabled) {
             Analytics::init($key, $options);
@@ -53,20 +48,8 @@ class SegmentIoProvider
     }
 
     /**
-     * @param string $name
-     * @param array  $params
-     * @return bool
-     */
-    private function process($name, array $params)
-    {
-        if ($this->isEnabled) {
-            return Analytics::$name($params);
-        }
-        return true;
-    }
-
-    /**
      * @param array $message
+     *
      * @return bool
      */
     public function track(array $message)
@@ -76,6 +59,7 @@ class SegmentIoProvider
 
     /**
      * @param array $message
+     *
      * @return bool
      */
     public function identify(array $message)
@@ -85,6 +69,7 @@ class SegmentIoProvider
 
     /**
      * @param array $message
+     *
      * @return bool
      */
     public function page(array $message)
@@ -94,6 +79,7 @@ class SegmentIoProvider
 
     /**
      * @param array $message
+     *
      * @return bool
      */
     public function alias(array $message)
@@ -103,6 +89,7 @@ class SegmentIoProvider
 
     /**
      * @param array $message
+     *
      * @return bool
      */
     public function group(array $message)
@@ -118,12 +105,14 @@ class SegmentIoProvider
         if ($this->isEnabled) {
             return Analytics::flush();
         }
+
         return true;
     }
 
     /**
      * @param array  $msg
-     * @param $string
+     * @param string $string
+     *
      * @return bool
      */
     public function validate(array $msg, $string)
@@ -133,6 +122,22 @@ class SegmentIoProvider
         } catch (\Exception $e) {
             return false;
         }
+
+        return true;
+    }
+
+    /**
+     * @param string $name
+     * @param array  $params
+     *
+     * @return bool
+     */
+    private function process($name, array $params)
+    {
+        if ($this->isEnabled) {
+            return Analytics::$name($params);
+        }
+
         return true;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,12 @@
   "require": {
     "php": ">=5.4",
     "segmentio/analytics-php": "^1.2",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0",
+    "symfony/config": ">= 2.7",
+    "symfony/dependency-injection": ">= 2.7",
+    "symfony/http-kernel": ">= 2.7",
+    "doctrine/annotations": "1.*",
+    "symfony/security-core": ">= 2.7"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR contains : 
- Remove deprecation message on Symfony >=4.2
- Fix typo for [Symfony Coding Standard](https://symfony.com/doc/current/contributing/code/standards.html)