### PR TITLE
Fix ErrorHandler type in Provider constructor

### DIFF
--- a/Util/SegmentIoProvider.php
+++ b/Util/SegmentIoProvider.php
@@ -36,9 +36,9 @@ class SegmentIoProvider
      * @param string       $key
      * @param string       $environment
      * @param array        $options
-     * @param ErrorHandler $logger
+     * @param Callable     $logger
      */
-    public function __construct($key, $environment, array $options, ErrorHandler $logger)
+    public function __construct($key, $environment, array $options, Callable $logger)
     {
         $this->isEnabled = $environment === self::SEGMENT_IO_PROVIDER__ENV_PROD && $key;
         $options['error_handler'] = $logger;


### PR DESCRIPTION
This commit allows any other error handler to be injected in the constructor.

Example:

```yaml
# config/services.yaml

services:
    App\Services\CurlSegmentErrorHandler:
        decorates: farma.segment_io.error_handler
```