### PR TITLE
Add PHP Attributes compatibility

### DIFF
--- a/Configuration/Page.php
+++ b/Configuration/Page.php
@@ -13,7 +13,6 @@
 
 namespace Farmatholin\SegmentIoBundle\Configuration;
 
-use Doctrine\Common\Annotations\Annotation;
 use Doctrine\Common\Annotations\Annotation\Required;
 
 /**
@@ -22,9 +21,9 @@ use Doctrine\Common\Annotations\Annotation\Required;
  * @author Vladislav Marin <vladislav.marin92@gmail.com>
  *
  * @Annotation
- *
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 class Page implements AnalyticsInterface
 {
 
@@ -33,20 +32,40 @@ class Page implements AnalyticsInterface
      *
      * @var string
      */
-    public $category;
+    public string $category;
 
     /**
      * @Required
      *
      * @var string
      */
-    public $name;
+    public string $name;
 
     /**
      * @var array
      */
     public array $properties = [];
 
+    /**
+     * @param string $category
+     */
+    public function __construct(
+        $category = null,
+        string $name = null,
+        array $properties = []
+    ) {
+        if (is_array($category)) {
+            // Doctrine annotation
+            $this->category = $category['category'];
+            $this->name = $category['name'];
+            $this->properties = $category['properties'] ?? $this->properties;
+        } else {
+            // PHP Attributes
+            $this->category = $category;
+            $this->name = $name;
+            $this->properties = $properties;
+        }
+    }
 
     /**
      * @return string

--- a/Configuration/Track.php
+++ b/Configuration/Track.php
@@ -24,6 +24,7 @@ use Doctrine\Common\Annotations\Annotation\Required;
  * @Annotation
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 class Track implements AnalyticsInterface
 {
     /**
@@ -31,7 +32,7 @@ class Track implements AnalyticsInterface
      *
      * @var string
      */
-    public $event;
+    public string $event;
 
     /**
      * @var array
@@ -47,6 +48,30 @@ class Track implements AnalyticsInterface
      * @var bool
      */
     public bool $useTimestamp = false;
+
+    /**
+     * @param string $event
+     */
+    public function __construct(
+        $event = null,
+        array $properties = [],
+        array $context = [],
+        bool $useTimestamp = false
+    ) {
+        if (is_array($event)) {
+            // Doctrine annotations
+            $this->event = $event['event'];
+            $this->properties = $event['properties'] ?? $this->properties;
+            $this->context = $event['context'] ?? $this->context;
+            $this->useTimestamp = $event['useTimestamp'] ?? $this->useTimestamp;
+        } else {
+            // PHP Attributes
+            $this->event = $event;
+            $this->properties = $properties;
+            $this->context = $context;
+            $this->useTimestamp = $useTimestamp;
+        }
+    }
 
     /**
      * @return string

--- a/EventListener/AttributeListener.php
+++ b/EventListener/AttributeListener.php
@@ -1,0 +1,96 @@
+<?php
+
+/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+
+namespace Farmatholin\SegmentIoBundle\EventListener;
+
+use Farmatholin\SegmentIoBundle\Configuration\Page;
+use Farmatholin\SegmentIoBundle\Configuration\Track;
+use Farmatholin\SegmentIoBundle\Util\SegmentIoProvider;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class AttributeListener
+{
+    protected SegmentIoProvider $segmentIoProvider;
+    protected TokenStorageInterface $tokenStorage;
+    protected string $guestId;
+
+    /**
+     * AttributeListener constructor.
+     *
+     * @param TokenStorageInterface $tokenStorage
+     * @param SegmentIoProvider     $segmentIoProvider
+     * @param string                $guestId
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, SegmentIoProvider $segmentIoProvider, string $guestId)
+    {
+        $this->segmentIoProvider = $segmentIoProvider;
+        $this->tokenStorage = $tokenStorage;
+        $this->guestId = $guestId;
+    }
+
+    public function onKernelController(ControllerEvent $event): void
+    {
+        $controller = $event->getController();
+
+        if (!is_array($controller)) {
+            return;
+        }
+
+        [$controllerObject, $methodName] = $controller;
+
+        $controllerReflectionObject = new \ReflectionObject($controllerObject);
+        $reflectionMethod = $controllerReflectionObject->getMethod($methodName);
+
+        $userId = $this->getUserId();
+        foreach ($reflectionMethod->getAttributes(Page::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            /** @var Page $page */
+            $page = $attribute->newInstance();
+
+            $message = $page->getMessage();
+            $message['userId'] = $userId;
+
+            $this->segmentIoProvider->page($message);
+
+            $this->segmentIoProvider->flush();
+        }
+        foreach ($reflectionMethod->getAttributes(Track::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            /** @var Track $track */
+            $track = $attribute->newInstance();
+
+            $message = $track->getMessage();
+            $message['userId'] = $userId;
+
+            $this->segmentIoProvider->track($message);
+
+            $this->segmentIoProvider->flush();
+        }
+    }
+
+    /**
+     * @return string|null
+     *
+     * @throws \ReflectionException
+     */
+    private function getUserId(): ?string
+    {
+        if (null === $token = $this->tokenStorage->getToken()) {
+            return $this->guestId;
+        }
+
+        if (!is_object($user = $token->getUser())) {
+            return $this->guestId;
+        }
+
+        $reflect = new \ReflectionClass($user);
+        if ($reflect->hasMethod('getId')) {
+            $userId = $user->getId();
+            if (null !== $userId) {
+                return $userId;
+            }
+        }
+
+        return $this->guestId;
+    }
+}

--- a/Resources/config/annotations.xml
+++ b/Resources/config/annotations.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="farma.segment_io.event_listener.annotation_listener.class">Farmatholin\SegmentIoBundle\EventListener\AnnotationListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="farma.segment_io.annotation_listener" class="%farma.segment_io.event_listener.annotation_listener.class%">
+            <argument type="service" id="annotation_reader" on-invalid="ignore" />
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="segment_io.analytics"/>
+            <argument>%farma.segment_io_guest_id%</argument>
+            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/attributes.xml
+++ b/Resources/config/attributes.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="farma.segment_io.event_listener.attribute_listener.class">Farmatholin\SegmentIoBundle\EventListener\AttributeListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="farma.segment_io.attribute_listener" class="%farma.segment_io.event_listener.attribute_listener.class%">
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="segment_io.analytics"/>
+            <argument>%farma.segment_io_guest_id%</argument>
+            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,14 +30,6 @@
             <argument type="service" id="farma.segment_io.error_handler" />
         </service>
 
-        <service id="farma.segment_io.annotation_listener" class="%farma.segment_io.event_listener.annotation_listener.class%">
-            <argument type="service" id="annotation_reader" />
-            <argument type="service" id="security.token_storage" />
-            <argument type="service" id="segment_io.analytics"/>
-            <argument>%farma.segment_io_guest_id%</argument>
-            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
-        </service>
-
     </services>
 
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -11,6 +11,12 @@ Install
 
     $ php composer.phar require "farmatholin/segment-io-bundle":"dev-master"
 
+Install Doctrine Annotations package if needed
+
+.. code-block:: bash
+
+    $ php composer.phar require "doctrine/annotations":"^2.0"
+
 Enable the bundle in the kernel:
 
 .. code-block:: php

--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -39,3 +39,23 @@ If user doesn't exit, id set to 'guest' or from configuration 'guest_id'
     {
         // your code
     }
+
+
+Usage with Attributes
+----------------------
+
+User for attributes is getting from TokenStorage.
+If user doesn't exit, id set to 'guest' or from configuration 'guest_id'
+
+.. code-block:: php
+
+    use Farmatholin\SegmentIoBundle\Configuration\Page;
+    use Farmatholin\SegmentIoBundle\Configuration\Track;
+
+    #[Route('/', name: 'homepage')]
+    #[Page('index', category: 'page', properties: ['foo' => 'bar'])]
+    #[Track('visit homepage', properties: ['bar' => 'foo'], context: ['aa' => 'bb'], useTimestamp: true)]
+    public function indexAction(Request $request)
+    {
+        // your code
+    }

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,14 @@
     "symfony/config": ">= 2.7",
     "symfony/dependency-injection": ">= 2.7",
     "symfony/http-kernel": ">= 2.7",
-    "doctrine/annotations": "1.* || 2.*",
     "symfony/security-core": ">= 2.7"
   },
   "autoload": {
     "psr-4": {
       "Farmatholin\\SegmentIoBundle\\": "."
     }
+  },
+  "suggest": {
+    "doctrine/annotations": "This package is required to use annotations instead of PHP attributes"
   }
 }


### PR DESCRIPTION
This PR contains the code for adding compatibility with PHP 8 attributes, without having to modify the minimum version of PHP or Doctrine annotations. A minor version can therefore be published.

In a major version, I suggest removing Doctrine annotations, or at least adding a minimum version at `1.12` to have [named constructors](https://www.doctrine-project.org/projects/doctrine-annotations/en/2.0/custom.html#optional-constructors-with-named-parameters).

It would be interesting to add compatibility with [Symfony's HTTP client via contracts](https://symfony.com/doc/current/http_client.html#symfony-contracts).