### PR TITLE
Fix Symfony depreciation

### DIFF
--- a/DependencyInjection/SegmentIoExtension.php
+++ b/DependencyInjection/SegmentIoExtension.php
@@ -16,7 +16,6 @@ namespace Farmatholin\SegmentIoBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
@@ -40,6 +39,8 @@ class SegmentIoExtension extends Extension implements CompilerPassInterface
     /**
      * @param array            $configs
      * @param ContainerBuilder $container
+     *
+     * @return void
      *
      * @throws \Exception
      */
@@ -68,6 +69,11 @@ class SegmentIoExtension extends Extension implements CompilerPassInterface
         $container->setParameter('farma.segment_io_options', $config['options']);
     }
 
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @return void
+     */
     public function process(ContainerBuilder $container)
     {
         // Doctrine annotations can be disabled by Symfony Framework or if doctrine/annotations is missing


### PR DESCRIPTION
With Symfony 6.4, we have two depreciation warning in the profiler:

> Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Farmatholin\SegmentIoBundle\DependencyInjection\SegmentIoExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

> Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Farmatholin\SegmentIoBundle\DependencyInjection\SegmentIoExtension" now to avoid errors or add an explicit @return annotation to suppress this message.