### PR TITLE
Fix depreciation for PHP 8.4

### DIFF
--- a/Configuration/Page.php
+++ b/Configuration/Page.php
@@ -51,7 +51,7 @@ class Page implements AnalyticsInterface
      */
     public function __construct(
         $category = null,
-        string $name = null,
+        ?string $name = null,
         array $properties = []
     ) {
         if (is_array($category)) {


### PR DESCRIPTION
The explicit nullable type is used for PHP 8.4